### PR TITLE
feat(integrity): expose integrity or checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarn-lock-parser"
 description = "yarn.lock parser"
-version = "0.3.2"
+version = "0.4.0"
 authors = [
   "Roberto Huertas <roberto.huertas@outlook.com>",
   "Riccardo Attilio Galli <riccardo@sideralis.org>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub struct Entry<'a> {
 }
 
 /// Accepts the `yarn.lock` content and returns all the entries.
+/// # Errors
+/// - `YarnLockError`
 pub fn parse_str(content: &str) -> Result<Vec<Entry>, YarnLockError> {
     parse(content).map(|(_, entries)| entries).map_err(|e| {
         e.map(|ve| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ fn parse_entry(input: &str) -> Res<&str, Entry> {
             let (descriptors, entry_items) = res;
 
             // descriptors is guaranteed to be of length >= 1
-            let first_descriptor = descriptors.get(0).expect("Somehow descriptors is empty");
+            let first_descriptor = descriptors.first().expect("Somehow descriptors is empty");
 
             let name = first_descriptor.0;
 


### PR DESCRIPTION
The entries will have an integrity property which will contain the integrity string for v1 lock files and the checksum string for v2 files.

fixes #8